### PR TITLE
Add MediaWiki authentication to node

### DIFF
--- a/services/api/mw2pdf/classes/MediaWikiSession.js
+++ b/services/api/mw2pdf/classes/MediaWikiSession.js
@@ -1,0 +1,74 @@
+import { v4 as uuidv4 } from 'uuid'
+import puppeteer from 'puppeteer'
+
+import {
+  makeLoginRequest,
+  makeLoginTokenRequest,
+  extractLoginToken,
+} from '../utils/mediaWiki.js'
+
+import {
+  parseCookies,
+  toCookieString,
+} from '../utils/cookies.js'
+
+export class MediaWikiSession {
+  constructor(settings) {
+  	this.cookies = {}
+  }
+
+  isAuthenticated(domain) { return (domain in this.cookies) }
+
+  /**
+   * Remove any stored authentication cookies.
+   */
+  resetAuthentication() { this.cookies = {} }
+
+  getCookies(domain) { return this.cookies[domain] ?? [] }
+
+  setCookies(domain, cookies) { this.cookies[domain] = cookies }
+
+  /**
+   * Authenticate against a given api URL.
+   * If the authentication has already occurred for a given domain, this will NOT re-authenticate.
+   */
+  async authenticate(username, password, apiUrl) {
+  	const { host: domain } = new URL(apiUrl)
+  	if (this.isAuthenticated(domain)) {
+  		return true
+  	}
+
+    // Step 1: Generate a login token
+    const loginTokenRequest = await makeLoginTokenRequest(apiUrl)
+    const authCookies = parseCookies(domain, loginTokenRequest)
+    const loginToken = await extractLoginToken(loginTokenRequest)
+
+    // Step 2: Perform the login
+    const loginRequest = await makeLoginRequest({
+      apiUrl,
+      username,
+      password,
+      loginToken,
+      cookies: authCookies,
+    })
+    this.setCookies(
+    	domain,
+    	parseCookies(domain, loginRequest),
+    )
+    return true
+  }
+
+  async generatePdf(url, tmpDirectory = './') {
+    const browser = await puppeteer.launch(
+      { args: ['--no-sandbox', '--disable-setuid-sandbox'] }
+    )
+    const page = await browser.newPage()
+    const pdfPath = `${tmpDirectory}${uuidv4()}.pdf`
+  	const { host: domain } = new URL(url)
+    await page.setCookie(...this.getCookies(domain))
+    await page.goto(url, { waitUntil: 'networkidle2' })
+    await page.pdf({ path: pdfPath, format: 'A4' })
+    await browser.close()
+    return pdfPath
+  }
+}

--- a/services/api/mw2pdf/package.json
+++ b/services/api/mw2pdf/package.json
@@ -13,10 +13,12 @@
     "commander": "^6.2.0",
     "cookiefile": "^1.0.10",
     "hummus-recipe": "^2.0.0",
+    "node-fetch": "^2.6.1",
     "pdf-merger-js": "^3.0.5",
     "pdfjs-dist": "^2.5.207",
     "pdfmake": "^0.1.68",
     "puppeteer": "^5.5.0",
     "tough-cookie": "^4.0.0"
+    "uuid": "^8.3.2"
   }
 }

--- a/services/api/mw2pdf/package.json
+++ b/services/api/mw2pdf/package.json
@@ -18,7 +18,6 @@
     "pdfjs-dist": "^2.5.207",
     "pdfmake": "^0.1.68",
     "puppeteer": "^5.5.0",
-    "tough-cookie": "^4.0.0"
     "uuid": "^8.3.2"
   }
 }

--- a/services/api/mw2pdf/package.json
+++ b/services/api/mw2pdf/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "type": "module",
   "author": "Open Tech Strategies",
   "license": "AGPL-3.0-or-later",
   "dependencies": {

--- a/services/api/mw2pdf/utils/cookies.js
+++ b/services/api/mw2pdf/utils/cookies.js
@@ -1,0 +1,13 @@
+
+export function parseCookies(domain, response) {
+  const raw = response.headers.raw()['set-cookie'];
+  return raw.map((entry) => {
+    const [cookie] = entry.split(';')
+    const [name, value] = cookie.split('=')
+    return { name, value, domain};
+  });
+}
+
+export function toCookieString(cookies) {
+  return cookies.map(cookie => `${cookie.name}=${cookie.value}`).join(';')
+}

--- a/services/api/mw2pdf/utils/mediaWiki.js
+++ b/services/api/mw2pdf/utils/mediaWiki.js
@@ -1,0 +1,61 @@
+import fetch from 'node-fetch'
+import { toCookieString } from './cookies.js'
+
+export async function makeLoginTokenRequest(apiUrl) {
+  const loginTokenRequestParams = new URLSearchParams({
+    'action': 'query',
+    'meta': 'tokens',
+    'format': 'json',
+    'type': 'login',
+  })
+  const loginTokenRequestResult = await fetch(
+    apiUrl,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded'
+      },
+      body: loginTokenRequestParams.toString(),
+    }
+  )
+  return loginTokenRequestResult
+}
+
+export async function extractLoginToken(loginTokenRequestResult) {
+  const { query: { tokens: { logintoken: loginToken } } } = await loginTokenRequestResult.json()
+  return loginToken
+}
+
+export async function makeLoginRequest({
+  apiUrl,
+  username,
+  password,
+  loginToken,
+  cookies,
+} = {}) {
+  const loginActionRequestBody = new URLSearchParams({
+    format: 'json',
+    action: 'clientlogin',
+    username,
+    password,
+    loginreturnurl: 'http://google.com/',
+    logintoken: loginToken,
+  })
+  const loginActionRequestResult = await fetch(
+    apiUrl,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'cookie': toCookieString(cookies),
+      },
+      body: loginActionRequestBody.toString(),
+    }
+  )
+  return loginActionRequestResult
+}
+
+export function getApiUrlFromMediaWikiUrl(url) {
+	const [baseUrl] = url.split('/index.php')
+	return `${baseUrl}/api.php`
+}

--- a/services/api/mw2pdf/yarn.lock
+++ b/services/api/mw2pdf/yarn.lock
@@ -1190,11 +1190,6 @@ proxy-from-env@^1.0.0:
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
   integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
-psl@^1.1.33:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/psl/-/psl-1.8.0.tgz#9326f8bcfb013adcc005fdff056acce020e51c24"
-  integrity sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==
-
 pump@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
@@ -1202,11 +1197,6 @@ pump@^3.0.0:
   dependencies:
     end-of-stream "^1.1.0"
     once "^1.3.1"
-
-punycode@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
-  integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
 puppeteer@^5.5.0:
   version "5.5.0"
@@ -1565,15 +1555,6 @@ tiny-inflate@^1.0.0, tiny-inflate@^1.0.2, tiny-inflate@^1.0.3:
   resolved "https://registry.yarnpkg.com/tiny-inflate/-/tiny-inflate-1.0.3.tgz#122715494913a1805166aaf7c93467933eea26c4"
   integrity sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==
 
-tough-cookie@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.0.0.tgz#d822234eeca882f991f0f908824ad2622ddbece4"
-  integrity sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==
-  dependencies:
-    psl "^1.1.33"
-    punycode "^2.1.1"
-    universalify "^0.1.2"
-
 type-check@~0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
@@ -1636,11 +1617,6 @@ unicode-trie@^2.0.0:
     pako "^0.2.5"
     tiny-inflate "^1.0.0"
 
-universalify@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
-  integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
-
 unorm@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/unorm/-/unorm-1.6.0.tgz#029b289661fba714f1a9af439eb51d9b16c205af"
@@ -1651,7 +1627,7 @@ util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
-uuid@^8.3.1:
+uuid@^8.3.1, uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==


### PR DESCRIPTION
This PR sets the stage for moving MediaWiki authentication logic out of shell and into the `mw2pdf` code base.  Specifically, it introduces a new `MediaWikiSession` module which will allow us to separate the auth + rendering of a given page from the collation logic.

This also begins to refactor the code base a bit, moving us to node modules and starting to add some directory structure for code organization.

The new code is not integrated / run by a calling agent, but I confirmed it works by running the following in a `sandbox.js` file (`node sandbox.js`) against an instance of [torque-devenv](https://github.com/OpenTechStrategies/torque-devenv).

```
import { MediaWikiSession } from './classes/MediaWikiSession.js'

async function x() {
  const session = new MediaWikiSession()
  const apiUrl = 'http://127.0.0.1/LLIIA2020/api.php'
  await session.authenticate('admin', 'admin_password', apiUrl)
  await session.generatePdf('http://127.0.0.1/LLIIA2020/index.php')
}

x()
```