### PR TITLE
Configure basic logging

### DIFF
--- a/services/api/app.py
+++ b/services/api/app.py
@@ -4,6 +4,10 @@ from flask import Flask, request, send_file
 from rq import Queue, get_current_job
 from rq.job import Job
 from worker import conn
+import logging
+import sys
+
+logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 
 
 app = Flask(__name__)


### PR DESCRIPTION
This PR configures the Python `logger` to emit to stdout.  The `rq` package uses `logger` so this makes it possible for worker logs to be routed to a log file by whatever tool a developer is using to run the worker.

Resolves #10