### PR TITLE
Update pip lock file

### DIFF
--- a/services/api/Pipfile.lock
+++ b/services/api/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d583ec31086c052e6b2f610d762f577a86b40955c6329d821a90365ee2d4066a"
+            "sha256": "4e37ada7071ff14251230136123fde1caea26687a2d2b76a502d14a2b82485d4"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -30,6 +30,13 @@
             ],
             "index": "pypi",
             "version": "==1.1.2"
+        },
+        "gunicorn": {
+            "hashes": [
+                "sha256:e0a968b5ba15f8a328fdfd7ab1fcb5af4470c28aaf7e55df02a99bc13138e6e8"
+            ],
+            "index": "pypi",
+            "version": "==20.1.0"
         },
         "itsdangerous": {
             "hashes": [
@@ -111,11 +118,11 @@
         },
         "rq": {
             "hashes": [
-                "sha256:0291603f0c5bb0ef18363f6b325ae76076c1d79bb918e052aac1f8da2297dbfb",
-                "sha256:e0435db8e8afd2f83fd17262722d02a4455403a8a6344670186497474d74ce3a"
+                "sha256:2a253385bec82f0e723ad25fb547d3892900a94b3c3acc53514c4bd74897cb69",
+                "sha256:d861f1e794b595ae83f7b919d0c56d7102bc18f4f7b71395446d60d70344577c"
             ],
             "index": "pypi",
-            "version": "==1.7.0"
+            "version": "==1.8.0"
         },
         "werkzeug": {
             "hashes": [


### PR DESCRIPTION
This PR synchronizes my lock file with the repository.

`gunicorn` hadn't made it into the lock file somehow, and `rq`'s version updated as well somewhere along the line.