### PR TITLE
Ignore build files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ npm-debug.log
 venv/
 *.pdf
 *.jar
+
+# Ignore node buld outputs
+/services/api/mw2pdf/built/


### PR DESCRIPTION
We transpile TypeScript to JavaScript but didn't ignore the resulting
builds from version control.

Resolves #35