### PR TITLE
Support page size

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -193,7 +193,7 @@
 				"papersize": {
 					"type": "select",
 					"label-message": "coll-setting-papersize",
-					"default": "a4",
+					"default": "letter",
 					"options": {
 						"coll-setting-papersize-a4": "a4",
 						"coll-setting-papersize-letter": "letter"

--- a/services/api/app.py
+++ b/services/api/app.py
@@ -14,7 +14,7 @@ app = Flask(__name__)
 q = Queue(connection=conn)
 
 
-def print_to_pdf(urls, passthrough_parameters, username, password):
+def print_to_pdf(urls, page_size, passthrough_parameters, username, password):
     job = get_current_job()
     params = [
         "node",
@@ -35,6 +35,12 @@ def print_to_pdf(urls, passthrough_parameters, username, password):
             "--passthroughParameters",
             passthrough_parameters,
         ])
+    if page_size:
+        params.extend([
+            "--pageSize",
+            page_size,
+        ])
+
     params.extend(urls)
     subprocess.call(params)
     return
@@ -44,7 +50,7 @@ def render_book(book_data, passthrough_parameters, username, password):
     urls = list(map(lambda i: i["url"], book_data["items"]))
     job = q.enqueue_call(
         func=print_to_pdf,
-        args=( urls, passthrough_parameters, username, password ),
+        args=( urls, book_data["papersize"], passthrough_parameters, username, password ),
         result_ttl=10000,
     )
     return {"collection_id": job.get_id(), "is_cached": False}

--- a/services/api/mw2pdf/src/classes/MediaWikiSession.ts
+++ b/services/api/mw2pdf/src/classes/MediaWikiSession.ts
@@ -1,4 +1,5 @@
 import puppeteer from 'puppeteer'
+import { PDFFormat } from 'puppeteer'
 import {
   PdfFactory
 } from './PdfFactory'
@@ -14,6 +15,9 @@ import {
 import {
   deletePdfs,
 } from '../utils/files'
+import {
+  pageSizeToPDFFormat,
+} from '../utils/validation'
 import { 
   Pdf,
   PdfConstructorOptions
@@ -32,10 +36,10 @@ export interface MwPdfOptions {
   workDirectory: string
   makeTitlePage: boolean
   title: string
+  pageSize: string
 }
 export const MwPdfMakeTitlePage: boolean = true
 export const MwPdfDoNoteMakeTitlePage: boolean = false
-
 
 export class MediaWikiSession {
 
@@ -125,7 +129,7 @@ export class MediaWikiSession {
     const pagePdf: Pdf = PdfFactory.generatePdfObject(new PdfConstructorOptions(pageTitle, pageFilename))
 
     // print the visible page into a PDF
-    await page.pdf({ path: pagePdf.filename, format: 'A4' })
+    await page.pdf({ path: pagePdf.filename, format: pageSizeToPDFFormat(options.pageSize) })
 
     await browser.close()
 
@@ -137,7 +141,7 @@ export class MediaWikiSession {
     if (options.makeTitlePage) {
       const titlePagePdfFilename = join(options.workDirectory, `${v4()}.pdf`)
       const titlePagePdf = PdfFactory.generatePdfObject(new PdfConstructorOptions(pageTitle, titlePagePdfFilename))
-      await PdfFactory.generateTitlePagePdf(pageTitle, titlePagePdf)
+      await PdfFactory.generateTitlePagePdf(pageTitle, titlePagePdf, options.pageSize)
 
       const titlePageAndPagePdfFilename = join(options.workDirectory, `${v4()}.pdf`)
       const titlePageAndPagePdf = PdfFactory.generatePdfObject(new PdfConstructorOptions(pageTitle, titlePageAndPagePdfFilename))
@@ -162,7 +166,8 @@ export class MediaWikiSession {
           title: 'No Title',
           output: null,
           workDirectory: options.workDirectory,
-          makeTitlePage: MwPdfMakeTitlePage
+          makeTitlePage: MwPdfMakeTitlePage,
+          pageSize: options.pageSize,
         }
         return this.makePdf(url, pagePdfOptions)
       }),
@@ -181,7 +186,7 @@ export class MediaWikiSession {
     // Generate the table of contents
     const tableOfContentsPdfFilename = join(options.workDirectory, `${v4()}.pdf` )
     const tableOfContentsPdf = PdfFactory.generatePdfObject(new PdfConstructorOptions('No Title', tableOfContentsPdfFilename))
-    await PdfFactory.generateTableOfContentsPdf(pagePdfs, tableOfContentsPdf)
+    await PdfFactory.generateTableOfContentsPdf(pagePdfs, tableOfContentsPdf, options.pageSize)
 
     // Merge the TOC with the page PDFs
     const finalPdfFilename = options.output ? options.output : join(options.workDirectory, `${v4()}.pdf` )

--- a/services/api/mw2pdf/src/classes/PdfFactory.ts
+++ b/services/api/mw2pdf/src/classes/PdfFactory.ts
@@ -9,6 +9,9 @@ import {
   StandardFonts,
 } from 'pdf-lib'
 import { Pdf, PdfConstructorOptions } from './Pdf'
+import {
+  pageSizeToPdfFactoryPageSize,
+} from '../utils/validation'
 
 // The below two lines are from
 // https://stackoverflow.com/questions/32705219/nodejs-accessing-file-with-relative-path/32707530#32707530
@@ -28,8 +31,9 @@ export class PdfFactory {
     return outPdf
   }
 
-  static async generateTitlePagePdf(title: string, outPdf: Pdf): Promise<void> {
+  static async generateTitlePagePdf(title: string, outPdf: Pdf, pageSize: string): Promise<void> {
     const scaffold = {
+      pageSize: pageSizeToPdfFactoryPageSize(pageSize),
       content: [
         {
           text: title,
@@ -51,7 +55,7 @@ export class PdfFactory {
     await PdfFactory.generatePdfFromScaffold(scaffold, outPdf)
   }
 
-  static async generateTableOfContentsPdf(pdfs: Array<Pdf>, outPdf: Pdf): Promise<void> {
+  static async generateTableOfContentsPdf(pdfs: Array<Pdf>, outPdf: Pdf, pageSize: string): Promise<void> {
 
     /**
      * Create a throwaway Toc datastructure to make the
@@ -90,6 +94,7 @@ export class PdfFactory {
     )
 
     const scaffold = {
+      pageSize: pageSizeToPdfFactoryPageSize(pageSize),
       content: [
         {
           text: 'Table of Contents',

--- a/services/api/mw2pdf/src/index.ts
+++ b/services/api/mw2pdf/src/index.ts
@@ -12,6 +12,7 @@ interface CommandOptions {
   subtitle: string
   passthroughParameters: string
   out: string
+  pageSize: string
 }
 
 program.version('0.0.1')
@@ -23,6 +24,7 @@ program
   .option('--subtitle <string>', 'Subtitle of book', 'Table of Contents')
   .option('--mwUsername <string>', 'The username to log in with', '')
   .option('--mwPassword <string>', 'The password to log in with', '')
+  .option('--pageSize <string>', 'The target page size for the book', 'Letter')
   .option('--passthroughParameters <string>', 'a json encoded string containing data to pass via querystring with each request', '')
   .action(async (urlStrings: Array<string>, options: CommandOptions) => {
     const mediaWikiSession = new MediaWikiSession()
@@ -74,6 +76,7 @@ program
       output: options.out,
       workDirectory: "./",
       makeTitlePage: true,
+      pageSize: options.pageSize,
     }
     await mediaWikiSession.makePdfBooklet(urls, pdfBookletOptions)
   })

--- a/services/api/mw2pdf/src/utils/validation.ts
+++ b/services/api/mw2pdf/src/utils/validation.ts
@@ -1,3 +1,4 @@
+import type { PDFFormat } from 'puppeteer'
 import Joi from 'joi'
 
 function isObject(value: Object): boolean {
@@ -50,4 +51,25 @@ export function assertValidPassthroughParameters(passthroughParameters: string):
     JSON.parse(passthroughParameters),
     passthroughParametersSchema,
   )
+}
+
+export function pageSizeToPDFFormat(pageSize: string): PDFFormat {
+  switch(pageSize.toLowerCase()) {
+    case 'a4':
+      return 'A4'
+    case 'letter':
+    default:
+      return 'Letter'
+  }
+}
+
+export function pageSizeToPdfFactoryPageSize(pageSize: string): string {
+  switch(pageSize.toLowerCase()) {
+    case 'a4':
+      return 'A4'
+    case 'letter':
+    default:
+      return 'LETTER'
+      return pageSize
+  }
 }


### PR DESCRIPTION
This PR fixes support for page size.  Page size existed in the UX from collection originally, but the new rendering logic didn't actually process the setting.

These settings themselves are set via AJAX and stored in cookies.

The PR also updates the default from `A4` to `Letter`

Resolves #40