### PR TITLE
Support missing parameters

### DIFF
--- a/services/api/app.py
+++ b/services/api/app.py
@@ -94,10 +94,10 @@ def render_status():
 def process_command():
     if request.form["command"] == "render":
         return render_book(
-            json.loads(request.form['metabook']),
-            request.form['passthrough_parameters'],
-            request.form['login_credentials[username]'],
-            request.form['login_credentials[password]'],
+            json.loads(request.form.get('metabook'), ''),
+            request.form.get('passthrough_parameters', ''),
+            request.form.get('login_credentials[username]', ''),
+            request.form.get('login_credentials[password]', ''),
         )
     elif request.form["command"] == "render_status":
         return render_status()


### PR DESCRIPTION
This PR fixes an issues where the python renderer would fail to generate books unless all possible form parameters were provided.  This was specifically causing issues where the username / password was not being sent; many wikis allow access without credentials, and book rendering should support that use case.

Resolves #50